### PR TITLE
Do not print task details when they are not explicitly set

### DIFF
--- a/cmsbooklet/templates/cms-contest/data/cms-contest.cls
+++ b/cmsbooklet/templates/cms-contest/data/cms-contest.cls
@@ -447,9 +447,9 @@
             \begin{tabular}{l@{\extracolsep{1cm}}l}
                 %\kw@InputFileName & \texttt{#3} \\
                 %\kw@OutputFileName & \texttt{#4} \\
-                \kw@TimeLimit & #5~\kw@seconds \\
-                \kw@MemoryLimit & #6~MiB \\
-		\kw@Difficulty & #7\\
+                \ifnum\pdfstrcmp{#5}{None}=0 \else \kw@TimeLimit & #5~\kw@seconds\\ \fi
+                \ifnum\pdfstrcmp{#6}{None}=0 \else \kw@MemoryLimit & #6~MiB\\ \fi
+                \ifnum\pdfstrcmp{#7}{None}=0 \else \kw@Difficulty & #7\\ \fi
             \end{tabular}
         }
         \nopagebreak

--- a/cmsbooklet/templates/cms-contest/defaults.yaml
+++ b/cmsbooklet/templates/cms-contest/defaults.yaml
@@ -9,6 +9,3 @@ contest:
 problem:
     infile: 'stdin'
     outfile: 'stdout'
-    time_limit: '1.0'
-    memory_limit: '256'
-    difficulty: '1'


### PR DESCRIPTION
Inside a `tabular` environment high level commands (such as `ifthenelse`) produce side effects, so we're forced to use low level TeX primitives. 
This makes the code slightly less readable (looking at the whole file... I'm not too worried :laughing: ) but achieves the goal.

Fixes #4 , which is now exacerbated by the fact that we also have difficulty.