### PR TITLE
Remove non POSIX compliant option from mktemp

### DIFF
--- a/scripts/mktesto
+++ b/scripts/mktesto
@@ -8,7 +8,7 @@ if [ -f contest.yaml ]
 then
     cmsbooklet -t cms-contest -l italian --only "$this_task" "$@" contest.yaml
 else
-    YAML=$(mktemp --tmpdir="$(pwd)")
+    YAML=$(mktemp "$PWD/contest.yaml.XXXXXXXX")
     echo "tasks:" >> "$YAML"
     echo " - $this_task" >> "$YAML"
     cmsbooklet -t cms-contest -l italian --only "$this_task" "$@" "$YAML"


### PR DESCRIPTION
The option `--tmpdir` is not a standard POSIX option, and thus it fails on systems that doesn't use GNU coreutils, like macOS.